### PR TITLE
Add action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Shuttle deploy actions
+# Shuttle deploy action
 
-Deploys current workspace to [shuttle.rs](https://www.shuttle.rs)
+Deploys current project to [shuttle.rs](https://www.shuttle.rs)
 
-Will checkout the repo if not already checked out
+Will checkout the repository if not already checked out
 
 ### Inputs
 
@@ -25,12 +25,9 @@ on:
       - "main"
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Check source
-        run: |
-          cargo check
       - uses: shuttle-hq/shuttle-deploy-action@main
         with:
           shuttle-deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Shuttle deploy actions
+
+Deploys current workspace to [shuttle.rs](https://www.shuttle.rs)
+
+Will checkout the repo if not already checked out
+
+### Inputs
+
+`shuttle-deploy-key`, the key found at https://www.shuttle.rs/login
+
+`working-directory`, the folder which includes the project, **defaults to `"."`**
+
+### Outputs
+
+None
+
+### Example usage
+
+```yml
+name: Shuttle deploy
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source
+        run: |
+          cargo check
+      - uses: shuttle-hq/shuttle-deploy-action@main
+        with:
+          shuttle-deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Will checkout the repository if not already checked out
 
 ### Inputs
 
-`shuttle-deploy-key`, the key found at https://www.shuttle.rs/login
+`deploy-key`, the key found at https://www.shuttle.rs/login
 
-`working-directory`, the folder which includes the project, **defaults to `"."`**
+`working-directory`, the directory which includes the `Cargo.toml`, **defaults to `"."`**
+
+`allow-dirty`, allow uncommitted changes to be deployed, **defaults to `"false"`**
 
 ### Outputs
 
@@ -28,7 +30,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: shuttle-hq/shuttle-deploy-action@main
+      - uses: shuttle-hq/deploy-action@main
         with:
-          shuttle-deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+          deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,13 +2,17 @@ name: Shuttle deploy
 description: "Deploy to shuttle"
 
 inputs:
-  shuttle-deploy-key:
-    description: 'The key found at "https://www.shuttle.rs/login"'
+  deploy-key:
+    description: 'the key found at "https://www.shuttle.rs/login"'
     required: true
   working-directory:
-    description: "directory which Cargo.toml is under"
+    description: "the directory which includes the `Cargo.toml`"
     required: false
     default: "."
+  allow-dirty:
+    description: "allow uncommitted changes to be deployed"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -25,10 +29,14 @@ runs:
         cargo quickinstall cargo-shuttle
       shell: bash
     - name: Log into shuttle
-      run: |
-        cargo shuttle login --api-key ${{ inputs.shuttle-deploy-key }} --allow-dirty
+      run: cargo shuttle login --api-key ${{ inputs.deploy-key }}
       shell: bash
     - name: Deploy to shuttle
+      if: ${{ inputs.allow-dirty == "false" }}
       run: cargo shuttle deploy | awk '!/Database URI.*?$/'
+      shell: bash
+    - name: Deploy to shuttle
+      if: ${{ inputs.allow-dirty != "false" }}
+      run: cargo shuttle deploy --allow-dirty | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Shuttle deploy
-description: 'Deploy to shuttle'
+description: "Deploy to shuttle"
 
 inputs:
   shuttle-deploy-key:
@@ -26,10 +26,9 @@ runs:
       shell: bash
     - name: Log into shuttle
       run: |
-        cargo shuttle login --api-key ${{ inputs.shuttle-deploy-key }}
+        cargo shuttle login --api-key ${{ inputs.shuttle-deploy-key }} --allow-dirty
       shell: bash
     - name: Deploy to shuttle
-      run:
-        cargo shuttle deploy | awk '!/Database URI.*?$/'
+      run: cargo shuttle deploy | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: Shuttle deploy
+description: 'Deploy to shuttle'
+
+inputs:
+  shuttle-deploy-key:
+    description: 'The key found at "https://www.shuttle.rs/login"'
+    required: true
+  working-directory:
+    description: "directory which Cargo.toml is under"
+    required: false
+    default: "."
+
+runs:
+  using: "composite"
+  steps:
+    - id: check-repo-is-not-initialized
+      run: echo "::set-output name=remote-url::$( git config --get remote.origin.url )"
+      shell: bash
+    - uses: actions/checkout@v2
+      if: ${{ !contains(steps.check-repo-is-not-initialized.outputs.remote-url, github.repository) }}
+    - name: Install shuttle cli
+      run: |
+        # using cargo-quickinstall because it is faster to get shuttle-cli binary
+        cargo install cargo-quickinstall
+        cargo quickinstall cargo-shuttle
+      shell: bash
+    - name: Log into shuttle
+      run: |
+        cargo shuttle login --api-key ${{ inputs.shuttle-deploy-key }}
+      shell: bash
+    - name: Deploy to shuttle
+      run:
+        cargo shuttle deploy | awk '!/Database URI.*?$/'
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash


### PR DESCRIPTION
Have written the action and the readme

Tested it at: https://github.com/kaleidawave/axum-shuttle-demo/runs/6608500678?check_suite_focus=true

The action part is all fine and works!

However there were some problems with the project on my end and so it failed to deploy. And as the shuttle-cli current returns a successful exit code for failed deployments the run shows a green tick. When https://github.com/shuttle-hq/shuttle/issues/138 is resolved the normal GitHub actions catch will work and not show a green tick for failed deploys... 

But the action part is working okay. It has a input for the shuttle key as well as being able to specify the folder if the project and `Shuttle.toml` is not at the root of the repository.

There could be some improvements here and there (deploy on a specific branch, maybe it should output something rather than just printing to log). But initially it works and can now wait for more feedback if things need to be more complex.

If this is merged to main it will work today using `shuttle-hq/shuttle-deploy-action@main`. At some point could tag and release it with specific version... 