### PR TITLE
Update the action to remove deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This action automates the deployment of a rust project to [Shuttle](https://www.shuttle.rs/). This action builds the project and then deploys the result to Shuttle.
 
+Note that you need to have created a project on Shuttle before you can deploy to it. This action will NOT create a new project for you.
+You can see the documentation on how to create a project [here](https://docs.shuttle.rs/introduction/quick-start).
+
 ## Inputs
 
 | Name | Description | Required | Default |

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
-# Shuttle deploy action
+# Shuttle Deploy Action
 
-Deploys current project to [shuttle.rs](https://www.shuttle.rs)
+This action automates the deployment of a rust project to [Shuttle](https://www.shuttle.rs/). This action builds the project and then deploys the result to Shuttle.
 
-Will checkout the repository if not already checked out
+## Inputs
 
-### Inputs
+| Name | Description | Required | Default |
+| --- | --- | --- | --- |
+| shuttle_api_key | The Shuttle API key | true | N/A |
+| working_directory | The directory which includes the `Cargo.toml` | false | `"."` |
+| allow_dirty | Allow uncommitted changes to be deployed | false | `"false"` |
 
-`deploy-key`, the key found at https://www.shuttle.rs/login
+## Outputs
 
-`working-directory`, the directory which includes the `Cargo.toml`, **defaults to `"."`**
+| Name | Description |
+| --- | --- |
+| shuttle_url | The URL of the deployed project |
 
-`allow-dirty`, allow uncommitted changes to be deployed, **defaults to `"false"`**
+## Example usage
 
-### Outputs
+### Typical Example
 
-None
-
-### Example usage
-
-```yml
+```yaml
 name: Shuttle deploy
 
 on:
@@ -32,5 +34,26 @@ jobs:
     steps:
       - uses: shuttle-hq/deploy-action@main
         with:
-          deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+          shuttle_api_key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+```
+
+### Example with all inputs
+
+```yaml
+name: Shuttle deploy
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shuttle-hq/deploy-action@main
+        with:
+          shuttle_api_key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
+          working_directory: "my-project"
+          allow_dirty: "true"
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
     - id: check-repo-is-not-initialized
       run: echo "::set-output name=remote-url::$( git config --get remote.origin.url )"
       shell: bash
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       if: ${{ !contains(steps.check-repo-is-not-initialized.outputs.remote-url, github.repository) }}
     - name: Install shuttle cli
       run: |

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,9 @@ runs:
       if: ${{ !contains(steps.check-repo-is-not-initialized.outputs.remote-url, github.repository) }}
     - name: Install shuttle cli
       run: |
-        # using cargo-quickinstall because it is faster to get shuttle-cli binary
-        cargo install cargo-quickinstall
-        cargo quickinstall cargo-shuttle
+        # using cargo-binstall because it is faster to get shuttle-cli binary
+        cargo install cargo-binstall
+        cargo binstall cargo-shuttle
       shell: bash
     - name: Log into shuttle
       run: cargo shuttle login --api-key ${{ inputs.deploy-key }}

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         # using cargo-binstall because it is faster to get shuttle-cli binary
         cargo install cargo-binstall
-        cargo binstall cargo-shuttle
+        cargo binstall -y cargo-shuttle
       shell: bash
     - name: Log into shuttle
       run: cargo shuttle login --api-key ${{ inputs.deploy-key }}

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - id: check-repo-is-not-initialized
-      run: echo "::set-output name=remote-url::$( git config --get remote.origin.url )"
+      run: echo "remote-url=$( git config --get remote.origin.url )" >> $GITHUB_OUTPUT
       shell: bash
     - uses: actions/checkout@v3
       if: ${{ !contains(steps.check-repo-is-not-initialized.outputs.remote-url, github.repository) }}


### PR DESCRIPTION
This pull request resolves two problems in the current version of the action:

1. It upgrades the actions/checkout action to v3 as v2 was deprecated.
2. It moves to the new way of specifying step outputs from the old `::set-output` method. (see [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))