### PR TITLE
Install cargo-binstall as binary. Add --no-test and version options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This action automates the deployment of a Rust project to [Shuttle](https://www.
 Note that you need to have created a project on Shuttle before you can deploy to it. This action will NOT create a new project for you.
 You can see the documentation on how to create a project [here](https://docs.shuttle.rs/introduction/quick-start).
 
+Shuttle Secrets are not handled by this action (yet). Add secrets using Secrets.toml with a manual deploy command. Read more about secrets [here](https://docs.shuttle.rs/resources/shuttle-secrets).
+
 ## Inputs
 
 | Name | Description | Required | Default |
@@ -63,6 +65,7 @@ jobs:
         with:
           deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
           working-directory: "backend"
+          name: "my-project"
           allow-dirty: "true"
           no-test: "true"
           cargo-shuttle-version: "0.21.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shuttle Deploy Action
 
-This action automates the deployment of a rust project to [Shuttle](https://www.shuttle.rs/). This action builds the project and then deploys the result to Shuttle.
+This action automates the deployment of a Rust project to [Shuttle](https://www.shuttle.rs/). This action deploys the project to Shuttle, which builds it and hosts it.
 
 Note that you need to have created a project on Shuttle before you can deploy to it. This action will NOT create a new project for you.
 You can see the documentation on how to create a project [here](https://docs.shuttle.rs/introduction/quick-start).
@@ -12,12 +12,14 @@ You can see the documentation on how to create a project [here](https://docs.shu
 | deploy-key | The Shuttle API key | true | N/A |
 | working-directory | The directory which includes the `Cargo.toml` | false | `"."` |
 | allow-dirty | Allow uncommitted changes to be deployed | false | `"false"` |
+| no-test | Don't run tests before deployment | false | `"false"` |
+| cargo-shuttle-version | Version of cargo-shuttle | false | `""` (latest) |
 
 ## Outputs
 
 | Name | Description |
 | --- | --- |
-| shuttle-url | The URL of the deployed project |
+<!-- | shuttle-url | The URL of the deployed project | -->
 
 ## Example usage
 
@@ -30,6 +32,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -49,6 +52,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -57,6 +61,8 @@ jobs:
       - uses: shuttle-hq/deploy-action@main
         with:
           deploy-key: ${{ secrets.SHUTTLE_DEPLOY_KEY }}
-          working-directory: "my-project"
+          working-directory: "backend"
           allow-dirty: "true"
+          no-test: "true"
+          cargo-shuttle-version: "0.21.0"
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ You can see the documentation on how to create a project [here](https://docs.shu
 | Name | Description | Required | Default |
 | --- | --- | --- | --- |
 | deploy-key | The Shuttle API key | true | N/A |
+| cargo-shuttle-version | Version of cargo-shuttle | false | `""` (latest) |
 | working-directory | The directory which includes the `Cargo.toml` | false | `"."` |
+| name | The directory which includes the `Cargo.toml` | false | `"."` |
 | allow-dirty | Allow uncommitted changes to be deployed | false | `"false"` |
 | no-test | Don't run tests before deployment | false | `"false"` |
-| cargo-shuttle-version | Version of cargo-shuttle | false | `""` (latest) |
 
 ## Outputs
 
@@ -26,7 +27,7 @@ You can see the documentation on how to create a project [here](https://docs.shu
 ### Typical Example
 
 ```yaml
-name: Shuttle deploy
+name: Shuttle Deploy
 
 on:
   push:
@@ -46,7 +47,7 @@ jobs:
 ### Example with all inputs
 
 ```yaml
-name: Shuttle deploy
+name: Shuttle Deploy
 
 on:
   push:

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: "false"
   cargo-shuttle-version:
-    description: "version of cargo-shuttle, default: latest"
+    description: "version of cargo-shuttle"
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -17,27 +17,28 @@ inputs:
 runs:
   using: "composite"
   steps:
+      # check out repo if not done already
     - id: check-repo-is-not-initialized
       run: echo "remote-url=$( git config --get remote.origin.url )" >> $GITHUB_OUTPUT
       shell: bash
     - uses: actions/checkout@v3
       if: ${{ !contains(steps.check-repo-is-not-initialized.outputs.remote-url, github.repository) }}
-    - name: Install shuttle cli
-      run: |
-        # using cargo-binstall because it is faster to get shuttle-cli binary
-        cargo install cargo-binstall
-        cargo binstall -y cargo-shuttle
-      shell: bash
-    - name: Log into shuttle
-      run: cargo shuttle login --api-key ${{ inputs.deploy-key }}
-      shell: bash
+
+      # using cargo-binstall because it is faster to get shuttle-cli binary
+    - name: Install cargo-binstall
+      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+    - name: Install cargo-shuttle
+      run: cargo binstall -y cargo-shuttle
+
     - name: Deploy to shuttle
       if: ${{ inputs.allow-dirty == 'false' }}
       run: cargo shuttle deploy | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}
-      shell: bash
+      env:
+        SHUTTLE_API_KEY: ${{ inputs.deploy-key }}
     - name: Deploy to shuttle
       if: ${{ inputs.allow-dirty != 'false' }}
       run: cargo shuttle deploy --allow-dirty | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}
-      shell: bash
+      env:
+        SHUTTLE_API_KEY: ${{ inputs.deploy-key }}

--- a/action.yml
+++ b/action.yml
@@ -1,26 +1,30 @@
 name: Shuttle Deploy
-description: "Deploy to Shuttle"
+description: Deploy to Shuttle
 
 inputs:
   deploy-key:
-    description: 'the key found at "https://www.shuttle.rs/login"'
+    description: 'The key found at "https://www.shuttle.rs/login"'
     required: true
+  cargo-shuttle-version:
+    description: "Version of cargo-shuttle"
+    required: false
+    default: ""
   working-directory:
-    description: "the directory which includes the `Cargo.toml`"
+    description: "The directory which includes the `Cargo.toml`"
     required: false
     default: "."
+  name:
+    description: "Name of the project (overrides crate name & Shuttle.toml)"
+    required: false
+    default: ""
   allow-dirty:
-    description: "allow uncommitted changes to be deployed"
+    description: "Allow uncommitted changes to be deployed"
     required: false
     default: "false"
   no-test:
-    description: "don't run tests before deployment"
+    description: "Don't run tests before deployment"
     required: false
     default: "false"
-  cargo-shuttle-version:
-    description: "version of cargo-shuttle"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -48,6 +52,7 @@ runs:
     - name: Deploy to Shuttle
       run: |
         cargo shuttle deploy \
+        $(if [ "${{ inputs.name }}" != "" ]; then echo "--name ${{ inputs.name }}"; fi) \
         $(if [ "${{ inputs.allow-dirty }}" != "false" ]; then echo --allow-dirty; fi) \
         $(if [ "${{ inputs.no-test }}" != "false" ]; then echo --no-test; fi) \
         | awk '!/Database URI.*?$/'

--- a/action.yml
+++ b/action.yml
@@ -42,11 +42,11 @@ runs:
       shell: bash
     - name: Install cargo-shuttle
       if: ${{ inputs.cargo-shuttle-version == '' }}
-      run: cargo binstall -y cargo-shuttle
+      run: cargo binstall -y --locked cargo-shuttle
       shell: bash
     - name: Install cargo-shuttle ${{ inputs.cargo-shuttle-version }}
       if: ${{ inputs.cargo-shuttle-version != '' }}
-      run: cargo binstall -y cargo-shuttle@${{ inputs.cargo-shuttle-version }}
+      run: cargo binstall -y --locked cargo-shuttle@${{ inputs.cargo-shuttle-version }}
       shell: bash
 
     - name: Deploy to Shuttle

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: ShuttleHQ deploy
-description: "Deploy to shuttle"
+name: Shuttle Deploy
+description: "Deploy to Shuttle"
 
 inputs:
   deploy-key:
@@ -13,6 +13,14 @@ inputs:
     description: "allow uncommitted changes to be deployed"
     required: false
     default: "false"
+  no-test:
+    description: "don't run tests before deployment"
+    required: false
+    default: "false"
+  cargo-shuttle-version:
+    description: "version of cargo-shuttle, default: latest"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -24,21 +32,26 @@ runs:
     - uses: actions/checkout@v3
       if: ${{ !contains(steps.check-repo-is-not-initialized.outputs.remote-url, github.repository) }}
 
-      # using cargo-binstall because it is faster to get shuttle-cli binary
+      # install with cargo-binstall
     - name: Install cargo-binstall
       run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+      shell: bash
     - name: Install cargo-shuttle
+      if: ${{ inputs.cargo-shuttle-version == '' }}
       run: cargo binstall -y cargo-shuttle
+      shell: bash
+    - name: Install cargo-shuttle ${{ inputs.cargo-shuttle-version }}
+      if: ${{ inputs.cargo-shuttle-version != '' }}
+      run: cargo binstall -y cargo-shuttle@${{ inputs.cargo-shuttle-version }}
+      shell: bash
 
-    - name: Deploy to shuttle
-      if: ${{ inputs.allow-dirty == 'false' }}
-      run: cargo shuttle deploy | awk '!/Database URI.*?$/'
+    - name: Deploy to Shuttle
+      run: |
+        cargo shuttle deploy \
+        $(if [ "${{ inputs.allow-dirty }}" != "false" ]; then echo --allow-dirty; fi) \
+        $(if [ "${{ inputs.no-test }}" != "false" ]; then echo --no-test; fi) \
+        | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}
       env:
         SHUTTLE_API_KEY: ${{ inputs.deploy-key }}
-    - name: Deploy to shuttle
-      if: ${{ inputs.allow-dirty != 'false' }}
-      run: cargo shuttle deploy --allow-dirty | awk '!/Database URI.*?$/'
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        SHUTTLE_API_KEY: ${{ inputs.deploy-key }}
+      shell: bash


### PR DESCRIPTION
This speeds up the installation step from some minutes to ~4s.
Also cleanup and add more flags.
Updated documentation.

I have tested the changes here: https://github.com/jonaro00/TabPortal/actions (run 10 - 12)