### PR TITLE
Add secrets input to simplify user workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ Shuttle Secrets are not handled by this action (yet). Add secrets using Secrets.
 
 ## Inputs
 
-| Name | Description | Required | Default |
-| --- | --- | --- | --- |
-| deploy-key | The Shuttle API key | true | N/A |
+| Name                  | Description | Required | Default |
+|-----------------------| --- | --- | --- |
+| deploy-key            | The Shuttle API key | true | N/A |
 | cargo-shuttle-version | Version of cargo-shuttle | false | `""` (latest) |
-| working-directory | The directory which includes the `Cargo.toml` | false | `"."` |
-| name | The directory which includes the `Cargo.toml` | false | `"."` |
-| allow-dirty | Allow uncommitted changes to be deployed | false | `"false"` |
-| no-test | Don't run tests before deployment | false | `"false"` |
+| working-directory     | The directory which includes the `Cargo.toml` | false | `"."` |
+| name                  | The directory which includes the `Cargo.toml` | false | `"."` |
+| allow-dirty           | Allow uncommitted changes to be deployed | false | `"false"` |
+| no-test               | Don't run tests before deployment | false | `"false"` |
+| secrets               | Content of the `Secrets.toml` file, if any | false | `""` |
 
 ## Outputs
 
@@ -69,4 +70,7 @@ jobs:
           allow-dirty: "true"
           no-test: "true"
           cargo-shuttle-version: "0.21.0"
+          secrets: |
+            MY_AWESOME_SECRET_1 = '${{ secrets.SECRET_1 }}'
+            MY_AWESOME_SECRET_2 = '${{ secrets.SECRET_2 }}'
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,12 @@ inputs:
     description: "Don't run tests before deployment"
     required: false
     default: "false"
+  secrets:
+    description: |
+      Content of the `Secrets.toml` file, if any.
+      Use multiline text with `|` in case of multiple secrets
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -47,6 +53,12 @@ runs:
     - name: Install cargo-shuttle ${{ inputs.cargo-shuttle-version }}
       if: ${{ inputs.cargo-shuttle-version != '' }}
       run: cargo binstall -y --locked cargo-shuttle@${{ inputs.cargo-shuttle-version }}
+      shell: bash
+
+    - name: Create secret file
+      if: ${{ inputs.secrets != '' }}
+      run: echo "${{ inputs.secrets }}" > Secrets.toml
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
 
     - name: Deploy to Shuttle


### PR DESCRIPTION
Hello 👋 

As mentionned in the title, this change is here to simplify user workflows.
An axample have also been added to the README:

```yml
- uses: shuttle-hq/deploy-action@main
  with:
    (...)
    secrets: |
      MY_AWESOME_SECRET_1 = '${{ secrets.SECRET_1 }}'
      MY_AWESOME_SECRET_2 = '${{ secrets.SECRET_2 }}'
```

Furthermore, I believe that with enough examples using this approach, users will not think of storing `Secrets.toml` in version control for it to work with Continuous Deployment.

Cheers !