### PR TITLE
Add configurable idle-minutes for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Shuttle Secrets are not handled by this action (yet). Add secrets using Secrets.
 | allow-dirty           | Allow uncommitted changes to be deployed | false | `"false"` |
 | no-test               | Don't run tests before deployment | false | `"false"` |
 | secrets               | Content of the `Secrets.toml` file, if any | false | `""` |
+| idle-minutes          | Duration in minutes that an idle project is kept alive before being put to sleep (0 to never sleep) | false | `"30"` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
       Use multiline text with `|` in case of multiple secrets
     required: false
     default: ""
+  idle-minutes:
+    description: Duration in minutes that an idle project is kept alive before being put to sleep (0 to never sleep)
+    required: false
+    default: "30"
 
 runs:
   using: "composite"
@@ -67,6 +71,7 @@ runs:
         $(if [ "${{ inputs.name }}" != "" ]; then echo "--name ${{ inputs.name }}"; fi) \
         $(if [ "${{ inputs.allow-dirty }}" != "false" ]; then echo --allow-dirty; fi) \
         $(if [ "${{ inputs.no-test }}" != "false" ]; then echo --no-test; fi) \
+        $(if [ "${{ inputs.idle-minutes }}" != "30" ]; then echo "--idle-minutes ${{ inputs.idle-minutes }}"; fi) \
         | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}
       env:


### PR DESCRIPTION
Hi,

I was working on a telegram bot that needed to be kept a live but realised that there was no option for me to do so (I ended up modifying it in a private action). I then found this closed issue #12 which this should close. Think this could be  sought after feature since bot deployment is fairly popular on shuttle.

Thanks!

Best Regards,
Reuben