### PR TITLE
feat: add idle-minutes parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Shuttle Secrets are not handled by this action (yet). Add secrets using Secrets.
 | working-directory     | The directory which includes the `Cargo.toml` | false | `"."` |
 | name                  | The directory which includes the `Cargo.toml` | false | `"."` |
 | allow-dirty           | Allow uncommitted changes to be deployed | false | `"false"` |
+| idle-minutes          | How long to wait before putting the project in an idle state due to inactivity. 0 means the project will never idle. | false | `"30"` |
 | no-test               | Don't run tests before deployment | false | `"false"` |
 | secrets               | Content of the `Secrets.toml` file, if any | false | `""` |
 
@@ -68,6 +69,7 @@ jobs:
           working-directory: "backend"
           name: "my-project"
           allow-dirty: "true"
+          idle-minutes: "10"
           no-test: "true"
           cargo-shuttle-version: "0.21.0"
           secrets: |

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Allow uncommitted changes to be deployed"
     required: false
     default: "false"
+  idle-minutes:
+    description: "Number of minutes to keep the deployment alive before stopping it"
+    required: false
+    default: ""
   no-test:
     description: "Don't run tests before deployment"
     required: false
@@ -66,6 +70,7 @@ runs:
         cargo shuttle deploy \
         $(if [ "${{ inputs.name }}" != "" ]; then echo "--name ${{ inputs.name }}"; fi) \
         $(if [ "${{ inputs.allow-dirty }}" != "false" ]; then echo --allow-dirty; fi) \
+        $(if [ "${{ inputs.idle-minutes }}" != "" ]; then echo "--idle-minutes ${{ inputs.idle-minutes }}"; fi) \
         $(if [ "${{ inputs.no-test }}" != "false" ]; then echo --no-test; fi) \
         | awk '!/Database URI.*?$/'
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
I was deploying a bot for a discord server and noted that the idle-minutes parameter wasn't in the yml.