### PR TITLE
Allow project restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Read more about **Shuttle Secrets** [here](https://docs.shuttle.rs/resources/shu
 | allow-dirty           | Allow uncommitted changes to be deployed | false | `"false"` |
 | no-test               | Don't run tests before deployment | false | `"false"` |
 | secrets               | Content of the `Secrets.toml` file, if any | false | `""` |
+| restart               | Restart project before deployment | false | `"false"` |
 
 ## Outputs
 
@@ -72,6 +73,7 @@ jobs:
           allow-dirty: "true"
           no-test: "true"
           cargo-shuttle-version: "0.28.1"
+          restart: "true"
           secrets: |
             MY_AWESOME_SECRET_1 = '${{ secrets.SECRET_1 }}'
             MY_AWESOME_SECRET_2 = '${{ secrets.SECRET_2 }}'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Don't run tests before deployment"
     required: false
     default: "false"
+  restart:
+    description: "Restart project before deployment"
+    required: false
+    default: "false"
   secrets:
     description: |
       Content of the `Secrets.toml` file, if any.
@@ -59,6 +63,16 @@ runs:
       if: ${{ inputs.secrets != '' }}
       run: echo "${{ inputs.secrets }}" > Secrets.toml
       working-directory: ${{ inputs.working-directory }}
+      shell: bash
+
+    - name: Restart project
+      if: ${{ inputs.restart != 'false' }}
+      run: |
+        cargo shuttle project restart \
+        $(if [ "${{ inputs.name }}" != "" ]; then echo "--name ${{ inputs.name }}"; fi)
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SHUTTLE_API_KEY: ${{ inputs.deploy-key }}
       shell: bash
 
     - name: Deploy to Shuttle


### PR DESCRIPTION
When upgrading shuttle version, a restart is required according to the docs: 
https://docs.shuttle.rs/configuration/shuttle-versions#upgrading-shuttle-version

This PR allows the action to restart the project before the deployment